### PR TITLE
CI cypress timeouts

### DIFF
--- a/cypress/integration/display_spec.ts
+++ b/cypress/integration/display_spec.ts
@@ -1,6 +1,7 @@
 describe('System display', () => {
   before(() => {
-    cy.visit('http://localhost:3000');
+    // Increase the initial loading timeout as we wait for the app to get served in CI
+    cy.visit('http://localhost:3000', { timeout: 120_000 });
   });
 
   it('can open the menu', () => {

--- a/cypress/integration/navigation_spec.ts
+++ b/cypress/integration/navigation_spec.ts
@@ -7,7 +7,8 @@ describe('System navigation', () => {
   const activeButtonColor = 'rgb(135, 206, 235)';
 
   before(() => {
-    cy.visit('http://localhost:3000');
+    // Increase the initial loading timeout as we wait for the app to get served in CI
+    cy.visit('http://localhost:3000', { timeout: 120_000 });
   });
 
   it('can open the navigation menu', () => {


### PR DESCRIPTION
Increase the initial cypress visit timeout as the ci seems to be failing occasionally due to the app not being up.